### PR TITLE
Set a lower bound for the minimum speed, if using PDF mode.

### DIFF
--- a/src/Trajectory_Simulation.cpp
+++ b/src/Trajectory_Simulation.cpp
@@ -511,7 +511,8 @@ using namespace std::placeholders;
 							result.weight*=Weight_Angle;
 							result.nScattering++;
 							//Check if we fall below the speed cutoff
-							if(event.Speed()<vMin)  
+							double speed= event.Speed();
+							if(speed<vMin || speed <1.0e-20)  
 							{
 								simulate = false;
 								result.final_event=event;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
 		int GIS_Domains=1;
 		if(GIS)
 		{
-			GIS_Domains = std::min(3,Importance_Domains(DM,Analytic_vMean,vMin_pdf,GIS_Kappa,Layers));
+			GIS_Domains = std::min(10,Importance_Domains(DM,Analytic_vMean,vMin_pdf,GIS_Kappa,Layers));
 			Compute_Importance_Boundaries(DM,Analytic_vMean,GIS_Domains,GIS_Splits,Layers);
 		}
 		//Pre-simulation output.


### PR DESCRIPTION
For long range forces, the number of scatterings is huge and can reduce the speed below very tiny numbers, which can then cause segmentation faults in Layer::MFP(double vDM).