### PR TITLE
Extra GIS setting to control max number of splitting layers; minor float precision bugfix

### DIFF
--- a/bin/.test_Semiconductor.cfg
+++ b/bin/.test_Semiconductor.cfg
@@ -50,6 +50,7 @@
 	splitting 		=	true;		//(de-)activate importance splitting	
 	splits 			=	3.0;			//number of splits at splitting surface
 	kappa 			=	3.0;		//choose between 1.0 and 10.0. Determines how fast the number of importance boundaries increases
+	maxLayers		=	15;		//maximum number of the GIS importance boudnaries
 
 //Shielding
 	//Atmosphere

--- a/include/Input_Parameters.hpp
+++ b/include/Input_Parameters.hpp
@@ -25,6 +25,7 @@ extern double IS_Angle;	  // Scattering Angle
 extern double IS_MFP;	  // MFP
 // Importance splitting
 extern bool GIS;
+extern int GIS_max_layers;
 extern double GIS_Splits;
 extern double GIS_Kappa;
 // Parameter scan

--- a/src/Input_Parameters.cpp
+++ b/src/Input_Parameters.cpp
@@ -25,6 +25,7 @@ double IS_Angle = 0.0;	 // Scattering Angle
 double IS_MFP	= 0.0;	 // MFP
 // Importance splitting
 bool GIS		  = false;
+int GIS_max_layers = 25;
 double GIS_Splits = 0.0;
 double GIS_Kappa  = 0.0;
 
@@ -272,11 +273,22 @@ void Read_Config_File(const char* inputfile, int rank)
 		cerr << "No 'kappa' setting in configuration file." << endl;
 		exit(EXIT_FAILURE);
 	}
+	// Max number of layers
+	try
+	{
+		GIS_max_layers = cfg.lookup("maxLayers");
+	}
+	catch(const SettingNotFoundException& nfex)
+	{
+		// if maxLayers is not in the config, using the default value - 25
+		GIS_max_layers = 25;
+	}
 	if(rank == 0 && GIS)
 	{
 		cout << "\t\tImportance Splitting\t[x]" << endl;
 		cout << "\t\t\tSplits:\t\t" << GIS_Splits << endl;
-		cout << "\t\t\tKappa:\t\t" << GIS_Kappa << endl
+		cout << "\t\t\tKappa:\t\t" << GIS_Kappa << endl;
+		cout << "\t\t\tMaxLayers:\t\t" << GIS_max_layers << endl        
 			 << endl;
 	}
 	else if(rank == 0)

--- a/src/Numerics_Functions.cpp
+++ b/src/Numerics_Functions.cpp
@@ -651,24 +651,21 @@ unsigned int Interpolation::Hunt(double x)
 // Find j such that list[j]<x<list[j+1]
 unsigned int Interpolation::Locate(double x)
 {
-    if(((xDomain[0] - x) > 0.0) || ((x - xDomain[1]) > 1e-8))
+    // tolerance to avoid float-precision errors when comparing x with the domain edges
+    double tolerance = (xDomain[1] - xDomain[0])*1e-8;
+    
+    if(((xDomain[0] - x) > tolerance) || ((x - xDomain[1]) > tolerance))
     {
         printf("\nError in Interpolation::Locate(): x = %e lies outside the domain [%e,%e].\n\n", x, xDomain[0], xDomain[1]);
         std::exit(EXIT_FAILURE);
     }
     else
     {
-        unsigned int j = 0;
+        // if x is slightly outside the domain (but within the tolerance), setting it to the corresponding domain edge
+        x = std::max(xDomain[0], std::min(xDomain[1], x));
+        
         // Use Bisection() or the Hunt method, depending of the last calls were correlated.
-        if(x - xDomain[1] > 0)
-        {
-            // Trying to fix a float-precision bug here by using the right edge of the domain if the requested x is slightly higher
-            j = corr ? Hunt(xDomain[1]) : Bisection(xDomain[1], 0, N_Data - 1);
-        }
-        else
-        {
-            j = corr ? Hunt(x) : Bisection(x, 0, N_Data - 1);
-        }
+        unsigned int j = corr ? Hunt(x) : Bisection(x, 0, N_Data - 1);
 
         // Check if the points are still correlated.
         corr = (fabs((j - jLast)) < 10);

--- a/src/Numerics_Functions.cpp
+++ b/src/Numerics_Functions.cpp
@@ -651,21 +651,31 @@ unsigned int Interpolation::Hunt(double x)
 // Find j such that list[j]<x<list[j+1]
 unsigned int Interpolation::Locate(double x)
 {
-	if(((xDomain[0] - x) > 0.0) || ((x - xDomain[1]) > 0.0))
-	{
-		printf("\nError in Interpolation::Locate(): x = %e lies outside the domain [%e,%e].\n\n", x, xDomain[0], xDomain[1]);
-		std::exit(EXIT_FAILURE);
-	}
-	else
-	{
-		// Use Bisection() or the Hunt method, depending of the last calls were correlated.
-		unsigned int j = corr ? Hunt(x) : Bisection(x, 0, N_Data - 1);
-		// Check if the points are still correlated.
-		corr = (fabs((j - jLast)) < 10);
+    if(((xDomain[0] - x) > 0.0) || ((x - xDomain[1]) > 1e-8))
+    {
+        printf("\nError in Interpolation::Locate(): x = %e lies outside the domain [%e,%e].\n\n", x, xDomain[0], xDomain[1]);
+        std::exit(EXIT_FAILURE);
+    }
+    else
+    {
+        unsigned int j = 0;
+        // Use Bisection() or the Hunt method, depending of the last calls were correlated.
+        if(x - xDomain[1] > 0)
+        {
+            // Trying to fix a float-precision bug here by using the right edge of the domain if the requested x is slightly higher
+            j = corr ? Hunt(xDomain[1]) : Bisection(xDomain[1], 0, N_Data - 1);
+        }
+        else
+        {
+            j = corr ? Hunt(x) : Bisection(x, 0, N_Data - 1);
+        }
 
-		jLast = j;
-		return j;
-	}
+        // Check if the points are still correlated.
+        corr = (fabs((j - jLast)) < 10);
+
+        jLast = j;
+        return j;
+    }
 }
 // Constructors
 Interpolation::Interpolation()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
 		int GIS_Domains = 1;
 		if(GIS)
 		{
-			GIS_Domains = std::min(10, Importance_Domains(DM, Analytic_vMean, vMin_pdf, GIS_Kappa, Layers));
+			GIS_Domains = std::min(GIS_max_layers, Importance_Domains(DM, Analytic_vMean, vMin_pdf, GIS_Kappa, Layers));
 			Compute_Importance_Boundaries(DM, Analytic_vMean, GIS_Domains, GIS_Splits, Layers);
 		}
 		// Pre-simulation output.
@@ -321,7 +321,7 @@ int main(int argc, char* argv[])
 				if(GIS)
 				{
 					int GIS_Domains_new = Importance_Domains(DM, Analytic_vMean, vCutoff, GIS_Kappa, Layers);
-					GIS_Domains			= std::min(25, std::min(GIS_Domains_new, GIS_Domains + 1));
+					GIS_Domains			= std::min(GIS_max_layers, std::min(GIS_Domains_new, GIS_Domains + 1));
 					Compute_Importance_Boundaries(DM, Analytic_vMean, GIS_Domains, GIS_Splits, Layers);
 				}
 				// Pre-simulation output.


### PR DESCRIPTION
- Add a maxLayers setting to the GIS configuration

> It is useful to limit the maximum number of splitting layers
> in GIS. It used to be hard-coded to 10 when running in the
> speed-distribution-only mode, and to 25 when running in the full limit
> calculation mode. This commit makes it configurable by introducing the
> maxLayers int setting into the config. If maxLayers is not provided in
> the config file, it is set to 25.

- Add 1e-8 tolerance into the Interpolation::Locate function to avoid float-precision problems on the domain edges